### PR TITLE
added bootstrap and navbar example

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "react": "^15.4.1",
+    "react-bootstrap": "^0.30.7",
     "react-dom": "^15.4.1",
     "react-router": "^3.0.0"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import './App.css';
-import Game from './Game.js'
+import Game from './Game';
+import { Header } from './Header';
 
 const App = (props) => {
   return (
     <div id="gameBody">
+      <Header />
       <Game />
     </div>
   );

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navbar, Nav, NavItem } from 'react-bootstrap';
+
+const navbar = (
+  <Navbar inverse>
+    <Navbar.Header>
+      <Navbar.Brand>Crystal-Tiger-Dice</Navbar.Brand>
+    </Navbar.Header>
+    <Nav pullRight>
+      <NavItem>New Game</NavItem>
+    </Nav>
+  </Navbar>
+);
+
+export const Header = () => {
+  return (
+    <nav>{ navbar }</nav>
+  );
+};


### PR DESCRIPTION
React-Bootstrap added and Navbar component created.

Navbar functionality not implemented, just meant as an example. Any of the components found on [react-bootstrap](https://react-bootstrap.github.io/) can be imported using the destructuring method and used like so: 
 
```js
import { Navbar, Form, Button } from 'react-bootstrap';

// Now we have access to them as components like

<Button bsStyle='danger' bsSize='large'>DANGERRRZONEEEEEEE!</Button>
```